### PR TITLE
Append the PID to the working directory name to handle simultaneous b…

### DIFF
--- a/HarnessBuilder.psm1
+++ b/HarnessBuilder.psm1
@@ -2,8 +2,9 @@ $utils = Microsoft.PowerShell.Core\Import-Module -Name $PSScriptRoot/Utils.psm1 
 $config = Microsoft.PowerShell.Management\Get-Content $PSScriptRoot/config.json | 
     Microsoft.PowerShell.Utility\ConvertFrom-Json -AsHashtable
 
-$WORK_DIR = "./working"
-
+# Use the current PID to give each box-ps run a unique working directory.
+# This allows multiple box-ps instances to analyze samples in the same directory.
+$WORK_DIR = "./working_" + $PID
 
 function StaticParamsCode {
 
@@ -477,7 +478,7 @@ function ClassFunctionOverrides {
     
                 $code += $signature + " {`r`n"
                 $code += "`t`$CODE_DIR = `"<CODE_DIR>`"`r`n"
-                $code += "`t`$WORK_DIR = `"./working`"`r`n"
+                $code += "`t`$WORK_DIR = `"./working_<PID>`"`r`n"
                 $code += $utils.TabPad($(BehaviorPropsCode -ClassFunc -SigAndArgs $sigAndArgs -BehaviorPropInfo $OverrideInfo["BehaviorPropInfo"]))
                 $behaviorsListCode = $(BuildStringArrayCode $OverrideInfo["Behaviors"])
 

--- a/ScriptInspector.psm1
+++ b/ScriptInspector.psm1
@@ -2,7 +2,9 @@ $utils = Microsoft.PowerShell.Core\Import-Module -Name $PSScriptRoot/Utils.psm1 
 $config = Microsoft.PowerShell.Management\Get-Content $PSScriptRoot/config.json | 
     Microsoft.PowerShell.Utility\ConvertFrom-Json -AsHashtable
 
-$WORK_DIR = "./working"
+# Use the current PID to give each box-ps run a unique working directory.
+# This allows multiple box-ps instances to analyze samples in the same directory.
+$WORK_DIR = "./working_" + $PID
 
 function ReplaceStaticNamespaces {
 

--- a/ScriptInspector.psm1
+++ b/ScriptInspector.psm1
@@ -2,10 +2,6 @@ $utils = Microsoft.PowerShell.Core\Import-Module -Name $PSScriptRoot/Utils.psm1 
 $config = Microsoft.PowerShell.Management\Get-Content $PSScriptRoot/config.json | 
     Microsoft.PowerShell.Utility\ConvertFrom-Json -AsHashtable
 
-# Use the current PID to give each box-ps run a unique working directory.
-# This allows multiple box-ps instances to analyze samples in the same directory.
-$WORK_DIR = "./working_" + $PID
-
 function ReplaceStaticNamespaces {
 
     param(
@@ -365,13 +361,14 @@ function ScrapeLanguageProbes {
 function PreProcessScript {
 
     param(
-        [string] $Script
+        [string] $Script,
+	[string] $PID
     )
 
     $Script = BoxifyScript $Script
-    ScrapeNetworkIOCs $Script | Microsoft.PowerShell.Utility\Out-File -Append "$WORK_DIR/scraped_network.txt" 
-    ScrapeFilePaths $Script | Microsoft.PowerShell.Utility\Out-File -Append "$WORK_DIR/scraped_paths.txt"
-    ScrapeEnvironmentProbes $Script | Microsoft.PowerShell.Utility\Out-File -Append "$WORK_DIR/scraped_probes.txt"
+    ScrapeNetworkIOCs $Script | Microsoft.PowerShell.Utility\Out-File -Append "./working_$PID/scraped_network.txt" 
+    ScrapeFilePaths $Script | Microsoft.PowerShell.Utility\Out-File -Append "./working_$PID/scraped_paths.txt"
+    ScrapeEnvironmentProbes $Script | Microsoft.PowerShell.Utility\Out-File -Append "./working_$PID/scraped_probes.txt"
 
     $separator = ("*" * 100 + "`r`n")
     $layerOut = $separator + $Script + "`r`n" + $separator

--- a/box-ps.ps1
+++ b/box-ps.ps1
@@ -489,7 +489,7 @@ else {
 
     # build harness and integrate script with it
     $harness = (BuildHarness).Replace("<CODE_DIR>", $PSScriptRoot).Replace("<PID>", $PID)
-    $ScriptContent = PreProcessScript $ScriptContent
+    $ScriptContent = PreProcessScript $ScriptContent $PID
 
     # attach the harness to the script
     $harnessedScript = $harness + "`r`n`r`n" + $ScriptContent

--- a/box-ps.ps1
+++ b/box-ps.ps1
@@ -65,14 +65,16 @@ class Report {
     [object] $PotentialIndicators
     [object] $EnvironmentProbes
     [hashtable] $Artifacts
+    [string] $WorkingDir
 
     Report([object[]] $actions, [string[]] $scrapedNetwork, [string[]] $scrapedPaths, 
-            [string[]] $scrapedEnvProbes, [hashtable] $artifactMap) {
-        $this.Actions = $actions
-        $this.PotentialIndicators = $this.CombineScrapedIOCs($scrapedNetwork, $scrapedPaths)
-        $this.EnvironmentProbes = $this.GenerateEnvProbeReport($scrapedEnvProbes)
-        $this.Artifacts = $artifactMap
-    }
+           [string[]] $scrapedEnvProbes, [hashtable] $artifactMap, [string] $workingDir) {
+               $this.Actions = $actions
+               $this.PotentialIndicators = $this.CombineScrapedIOCs($scrapedNetwork, $scrapedPaths)
+               $this.EnvironmentProbes = $this.GenerateEnvProbeReport($scrapedEnvProbes)
+               $this.Artifacts = $artifactMap
+               $this.WorkingDir = $workingDir               
+           }
 
     [hashtable] GenerateEnvProbeReport([string[]] $scrapedEnvProbes) {
 
@@ -308,14 +310,15 @@ function HarvestArtifacts {
 
 # remove imported modules and clean up non-output file system artifacts
 function CleanUp {
-
     Remove-Module HarnessBuilder -ErrorAction SilentlyContinue
     Remove-Module ScriptInspector -ErrorAction SilentlyContinue
     Remove-Module Utils -ErrorAction SilentlyContinue
     Remove-Item -Recurse $WORK_DIR
 }
 
-$WORK_DIR = "./working"
+# Use the current PID to give each box-ps run a unique working directory.
+# This allows multiple box-ps instances to analyze samples in the same directory.
+$WORK_DIR = "./working_" + $PID
 
 # pull down the box-ps docker container and run it in there
 if ($Docker) {
@@ -457,6 +460,7 @@ else {
         }
         $varObj | ConvertTo-Json | Out-File $WORK_DIR/input_env.json
     }
+
     # copy the given json file where the harness builder expects it
     elseif ($EnvFile) {
 
@@ -484,7 +488,7 @@ else {
     Write-Host -NoNewLine "[+] building script harness..."
 
     # build harness and integrate script with it
-    $harness = (BuildHarness).Replace("<CODE_DIR>", $PSScriptRoot)
+    $harness = (BuildHarness).Replace("<CODE_DIR>", $PSScriptRoot).Replace("<PID>", $PID)
     $ScriptContent = PreProcessScript $ScriptContent
 
     # attach the harness to the script
@@ -504,7 +508,7 @@ else {
         # crashing here would be cringy
         try {
             Write-Host "[-] sandboxing failed..."
-            Write-Host (Get-Content -ErrorAction stop -Raw ./working/stderr.txt)
+            Write-Host (Get-Content -ErrorAction stop -Raw $WORK_DIR/stderr.txt)
             if (!$NoCleanUp) {
                 CleanUp
             }
@@ -532,7 +536,7 @@ else {
     $artifactMap = HarvestArtifacts $actions
 
     # create the report and convert to JSON
-    $report = [Report]::new($actions, $scrapedNetwork, $scrapedPaths, $scrapedEnvProbes, $artifactMap)
+    $report = [Report]::new($actions, $scrapedNetwork, $scrapedPaths, $scrapedEnvProbes, $artifactMap, $WORK_DIR)
     $reportJson = $report | ConvertTo-Json -Depth 10
 
     Write-Host " done"

--- a/harness/administrative.ps1
+++ b/harness/administrative.ps1
@@ -10,7 +10,7 @@ using namespace Microsoft.PowerShell
 using namespace NewtonSoft.Json
 using namespace System
 
-$WORK_DIR = "./working"
+$WORK_DIR = "./working_<PID>"
 $CODE_DIR = "<CODE_DIR>"
 
 class Action <# lawsuit... I'll be here all week #> {

--- a/harness/manual_cmdlets.ps1
+++ b/harness/manual_cmdlets.ps1
@@ -41,7 +41,7 @@ function Invoke-Expression {
     
     RecordAction $([Action]::new(@("script_exec"), "Microsoft.PowerShell.Utility\Invoke-Expression", $behaviorProps, $MyInvocation, ""))
 
-    $modifiedCommand = PreProcessScript $Command
+    $modifiedCommand = PreProcessScript $Command "<PID>"
 
     # actually run it, assign the result for situations like...
     # ex. $foo = Invoke-Expression "New-Object System.Net.WebClient"
@@ -188,7 +188,7 @@ function Start-Job {
 	$invokeRes = ""
 	if ($script) {
 
-		$modifiedCommand = PreProcessScript $script
+		$modifiedCommand = PreProcessScript $script "<PID>"
 
 		# actually run it, assign the result for situations like...
 		# ex. $foo = Invoke-Expression "New-Object System.Net.WebClient"
@@ -278,7 +278,7 @@ function powershell.exe {
 
     RecordAction $([Action]::new(@("script_exec"), "powershell.exe", $behaviorProps, $MyInvocation, ""))
 
-    $boxifiedScript = PreProcessScript $behaviorProps["script"]
+    $boxifiedScript = PreProcessScript $behaviorProps["script"] "<PID>"
 
 	Microsoft.PowerShell.Utility\Invoke-Expression $boxifiedScript
 }

--- a/harness/manual_statics.ps1
+++ b/harness/manual_statics.ps1
@@ -31,7 +31,7 @@ static [System.Diagnostics.Process] Start([System.Diagnostics.ProcessStartInfo] 
         RecordAction $([Action]::new(@("script_exec"), "[System.Diagnostics.Process]::Start", $behaviorProps, $PSBoundParameters, $MyInvocation.Line, ""))
 
         # run the script
-        $boxifiedScript = PreProcessScript $script
+        $boxifiedScript = PreProcessScript $script "<PID>"
         Microsoft.PowerShell.Utility\Invoke-Expression $boxifiedScript
     }
     else {
@@ -56,7 +56,7 @@ static [System.Diagnostics.Process] Start([string] $fileName, [string] $argument
         RecordAction $([Action]::new(@("script_exec"), "[System.Diagnostics.Process]::Start", $behaviorProps, $PSBoundParameters, $MyInvocation.Line, ""))
 
         # run the script
-        $boxifiedScript = PreProcessScript $script
+        $boxifiedScript = PreProcessScript $script "<PID>"
         Microsoft.PowerShell.Utility\Invoke-Expression $boxifiedScript
     }
     else {
@@ -81,7 +81,7 @@ static [System.Diagnostics.Process] Start([string] $fileName, [string] $argument
         RecordAction $([Action]::new(@("script_exec"), "[System.Diagnostics.Process]::Start", $behaviorProps, $PSBoundParameters, $MyInvocation.Line, ""))
 
         # run the script
-        $boxifiedScript = PreProcessScript $script
+        $boxifiedScript = PreProcessScript $script "<PID>"
         Microsoft.PowerShell.Utility\Invoke-Expression $boxifiedScript
     }
     else {

--- a/harness/manual_statics.ps1
+++ b/harness/manual_statics.ps1
@@ -95,7 +95,7 @@ static [System.Diagnostics.Process] Start([string] $fileName, [string] $argument
 static [void] Copy([byte[]] $source, [object] $destination, [object] $startIndex, [object] $length) {
 
     $CODE_DIR = "<CODE_DIR>"
-    $WORK_DIR = "./working"
+    $WORK_DIR = "./working_<PID>"
     $behaviorProps = @{}
     $behaviorProps["bytes"] = @($source)
     
@@ -114,7 +114,7 @@ static [void] Copy([byte[]] $source, [object] $destination, [object] $startIndex
 static [void] Copy([long[]] $source, [object] $destination, [object] $startIndex, [object] $length) {
 
     $CODE_DIR = "<CODE_DIR>"
-    $WORK_DIR = "./working"
+    $WORK_DIR = "./working_<PID>"
     $behaviorProps = @{}
     $behaviorProps["bytes"] = @($source)
     
@@ -133,7 +133,7 @@ static [void] Copy([long[]] $source, [object] $destination, [object] $startIndex
 static [void] Copy([char[]] $source, [object] $destination, [object] $startIndex, [object] $length) {
 
     $CODE_DIR = "<CODE_DIR>"
-    $WORK_DIR = "./working"
+    $WORK_DIR = "./working_<PID>"
     $behaviorProps = @{}
     $behaviorProps["bytes"] = @($source)
     
@@ -152,7 +152,7 @@ static [void] Copy([char[]] $source, [object] $destination, [object] $startIndex
 static [void] Copy([short[]] $source, [object] $destination, [object] $startIndex, [object] $length) {
 
     $CODE_DIR = "<CODE_DIR>"
-    $WORK_DIR = "./working"
+    $WORK_DIR = "./working_<PID>"
     $behaviorProps = @{}
     $behaviorProps["bytes"] = @($source)
     


### PR DESCRIPTION
…ox-ps runs.

Running multiple analyses of samples in the same directory leads to collisions with the shared box-ps working/ directory. The changes in this pull request append the PID to the working directory name so there is no collision on the working directory.